### PR TITLE
Add support for cross-domain authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Python library to safely password spray in Active Directory, set pwned users as owned in Bloodhound and detect path to Domain Admins
 
 
-This library uses [python-ldap](https://www.python-ldap.org/en/python-ldap-3.3.0/) project for all LDAP operations.
+This library uses [ldap3](https://ldap3.readthedocs.io) project for all LDAP operations.
 
 | Chapters                                     | Description                                             |
 |----------------------------------------------|---------------------------------------------------------|
@@ -136,6 +136,9 @@ sprayhound -u simba -p Pentest123.. -d hackn.lab -dc 10.10.10.1 -lu pixis -lp P4
 
 # All domain users, single password
 sprayhound -p Pentest123.. -d hackn.lab -dc 10.10.10.1 -lu pixis -lp P4ssw0rd
+
+# All domain users, single password, using an account from a trusted domain
+sprayhound -p Pentest123.. -d hackn.lab -dc 10.10.10.1 -lu 'babdcatha.net\Babd' -lp P4ssw0rd
 
 # User as pass on all domain users
 sprayhound -d hackn.lab -dc 10.10.10.1 -lu pixis -lp P4ssw0rd

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 neo4j
-python-ldap
+ldap3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license="MIT",
     install_requires=[
         'neo4j',
-        'python-ldap'
+        'ldap3'
     ],
     python_requires='>=3.6',
     classifiers=(

--- a/sprayhound/modules/ldapconnection.py
+++ b/sprayhound/modules/ldapconnection.py
@@ -97,7 +97,7 @@ class LdapConnection:
             self.log.error("Service unavailable on {}://{}:{}".format(self.scheme, self.host, self.port))
             raise
         except ldap3.core.exceptions.LDAPInvalidCredentialsResult:
-            ERROR_LDAP_CREDENTIALS
+            return ERROR_LDAP_CREDENTIALS
         except Exception as e:
             self.log.error("Unexpected error while trying {}:{}".format(self.domain + "\\" + self.username, password))
             raise

--- a/sprayhound/modules/ldapconnection.py
+++ b/sprayhound/modules/ldapconnection.py
@@ -5,7 +5,6 @@
 
 import socket
 import ldap3
-from ldap.controls import SimplePagedResultsControl
 
 from sprayhound.modules.credential import Credential
 from sprayhound.utils.defines import *
@@ -163,7 +162,7 @@ class LdapConnection:
         try:
             # Load domain-wide policy.
             self._conn.search(default_policy_container, '(objectClass=*)', search_scope=ldap3.BASE, attributes=[ldap3.ALL_ATTRIBUTES, ldap3.ALL_OPERATIONAL_ATTRIBUTES])
-        except ldap.LDAPError as e:
+        except ldap3.core.exceptions.LDAPException as e:
             self.log.error("An LDAP error occurred while getting password policy")
             raise
         self.domain_threshold = int(self._conn.response[0]['attributes']['lockoutThreshold'])


### PR DESCRIPTION
Hi!

This pull request is to add support for cross domain authentication, which can be useful to spray domains when a trusted domain has been compromised.

In summary, I did the following:
 - Switched from ldap base authentication to NTLM authentication
 - Switched from the python-ldap library to the ldap3 library
 - Slightly modify the authentication code to handle usernames in the `DOMAIN\user` format

There is no change in the way the tool is called, the `-lu` parameter now simply supports supplying it with a string in the `DOMAIN\user` format when an account from a trusted domain is to be used. Any previous command should still produce the same output.

The modification was tested on a custom AD environement, as well as on the [GOAD](https://github.com/Orange-Cyberdefense/GOAD) environment and worked as expected. I couldn't find any feature broken by this modification.

I hope this can be useful, and would gladly take any criticism/advice on the subject.